### PR TITLE
Fix a bug with long error message

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -67,7 +67,7 @@ func inspectDefinition(pass *analysis.Pass, tlds map[*ast.CallExpr]struct{}, n a
 
 func toString(ex ast.Expr, info *types.Info) string {
 	if tv, ok := info.Types[ex]; ok && tv.Value != nil {
-		return tv.Value.String()
+		return tv.Value.ExactString()
 	}
 
 	return ""

--- a/testdata/defenition.go
+++ b/testdata/defenition.go
@@ -33,6 +33,10 @@ func DefineWell3() error {
 	return fmt.Errorf(errWellTemplate3, 13, ErrWellDefined1)
 }
 
+func DefineWell4() error {
+	return fmt.Errorf("well defined 14 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx %d: %w", 14, ErrWellDefined1)
+}
+
 func DefineBad1() error {
 	err := fmt.Errorf("bad defined 21 %d", 21) // want `do not define dynamic errors, use wrapped static errors instead: `
 	return err


### PR DESCRIPTION
I could see `do not define dynamic errors, use wrapped static errors instead` when the format string is longer than a certain length, even though it wraps an error properly. That's because of using `String()` which returns a shortened string if the value is long. (ref: https://golang.org/pkg/go/constant/#Value)