### PR TITLE
fix: nolint directives

### DIFF
--- a/comparison.go
+++ b/comparison.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-func inspectComparision(pass *analysis.Pass, n ast.Node) bool { // nolint: unparam
+func inspectComparision(pass *analysis.Pass, n ast.Node) bool { //nolint:unparam
 	// check whether the call expression matches time.Now().Sub()
 	be, ok := n.(*ast.BinaryExpr)
 	if !ok {

--- a/definition.go
+++ b/definition.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/tools/go/analysis"
 )
 
-var methods2check = map[string]map[string]func(*ast.CallExpr, *types.Info) bool{ // nolint: gochecknoglobals
+var methods2check = map[string]map[string]func(*ast.CallExpr, *types.Info) bool{ //nolint:gochecknoglobals
 	"errors": {"New": justTrue},
 	"fmt":    {"Errorf": checkWrap},
 }

--- a/err113.go
+++ b/err113.go
@@ -48,7 +48,7 @@ func render(fset *token.FileSet, x interface{}) string {
 func enumerateFileDecls(f *ast.File) map[*ast.CallExpr]struct{} {
 	res := make(map[*ast.CallExpr]struct{})
 
-	var ces []*ast.CallExpr // nolint: prealloc
+	var ces []*ast.CallExpr //nolint:prealloc
 
 	for _, d := range f.Decls {
 		ces = append(ces, enumerateDeclVars(d)...)


### PR DESCRIPTION
According to the [`nolintlint`](https://golangci-lint.run/usage/linters/#nolintlint) linter:
```
comparison.go:12:65: directive `// nolint: unparam` should be written without leading space as `//nolint: unparam` (nolintlint)
definition.go:11:82: directive `// nolint: gochecknoglobals` should be written without leading space as `//nolint: gochecknoglobals` (nolintlint)
err113.go:51:26: directive `// nolint: prealloc` should be written without leading space as `//nolint: prealloc` (nolintlint)
```