### PR TITLE
fix: handle function call arguments in rawString

### DIFF
--- a/comparison.go
+++ b/comparison.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/ast/inspector"
@@ -149,7 +150,11 @@ func rawString(x ast.Expr) string {
 	case *ast.SelectorExpr:
 		return fmt.Sprintf("%s.%s", rawString(t.X), t.Sel.Name)
 	case *ast.CallExpr:
-		return fmt.Sprintf("%s()", rawString(t.Fun))
+		args := make([]string, len(t.Args))
+		for i, arg := range t.Args {
+			args[i] = rawString(arg)
+		}
+		return fmt.Sprintf("%s(%s)", rawString(t.Fun), strings.Join(args, ", "))
 	}
 
 	return fmt.Sprintf("%s", x)

--- a/testdata/custom.go
+++ b/testdata/custom.go
@@ -59,3 +59,11 @@ type simpleType struct{ field string }
 func (s simpleType) Is(err error) bool {
 	return err == ErrWellDefined1 // want `do not compare errors directly \"err == ErrWellDefined1\", use \"errors\.Is\(err, ErrWellDefined1\)\" instead`
 }
+
+func ConvertError(err error) error {
+	return err
+}
+
+func ConvertErrorEqual(ce1, ce2 *CustomError) bool {
+	return ConvertError(ce1) != ce2 // want `do not compare errors directly \"ConvertError\(ce1\) != ce2\", use \"!errors.Is\(ConvertError\(ce1\), ce2\)\" instead`
+}


### PR DESCRIPTION
before fix
```go
return !errors.Is(ConvertError(), ce2)
```

after fix
```go
return !errors.Is(ConvertError(ce1), ce2)
```
